### PR TITLE
feat: add Docker support, and documentation for it

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+/uploads
+/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,29 @@
-FROM node:16
+FROM node:20
 
 # Create app directory
 WORKDIR /usr/src/app
 
+# Copy app files (see .dockerignore)
+COPY . ./
+
 # Install app dependencies
-# A wildcard is used to ensure both package.json AND package-lock.json are copied
-# where available (npm@5+)
-COPY package*.json ./
+RUN npm install --omit=dev
 
-# Download, and prepare the kepubify binary
-RUN wget https://github.com/pgaskin/kepubify/releases/download/v4.0.4/kepubify-linux-64bit
-RUN mv kepubify-linux-64bit /usr/local/bin/kepubify
-RUN chmod +x /usr/local/bin/kepubify
+# Download and install kepubify
+RUN wget https://github.com/pgaskin/kepubify/releases/download/v4.0.4/kepubify-linux-64bit && \
+    mv kepubify-linux-64bit /usr/local/bin/kepubify && \
+    chmod +x /usr/local/bin/kepubify
 
-COPY . .
+# Download and install kindlegen
+RUN wget https://archive.org/download/kindlegen2.9/kindlegen_linux_2.6_i386_v2_9.tar.gz && \
+    mkdir kindlegen && \
+    tar xvf kindlegen_linux_2.6_i386_v2_9.tar.gz --directory kindlegen && \
+    cp kindlegen/kindlegen /usr/local/bin/kindlegen && \
+    chmod +x /usr/local/bin/kindlegen && \
+    rm -rf kindlegen
+
+# Create uploads directory if it doesn't exist
+RUN mkdir uploads
 
 EXPOSE 3001
-CMD [ "node", "index" ]
+CMD [ "npm", "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:16
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY package*.json ./
+
+# Download, and prepare the kepubify binary
+RUN wget https://github.com/pgaskin/kepubify/releases/download/v4.0.4/kepubify-linux-64bit
+RUN mv kepubify-linux-64bit /usr/local/bin/kepubify
+RUN chmod +x /usr/local/bin/kepubify
+
+COPY . .
+
+EXPOSE 3001
+CMD [ "node", "index" ]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# send2ereader
+
+A self hostable service for sending ebooks to a Kobo or Kindle ereader through the built-in browser.
+
+## How To Run
+
+### On Your Host OS
+
+1. Have Node 16 installed
+2. Install this service's dependencies by running `$ npm install`
+3. Install [Kepubify](https://github.com/pgaskin/kepubify), and have the executable in your path.
+4. Start this service by running: `$ node index`
+
+### Containerized
+
+1. Have Docker installed
+2. Run `$ docker compose up`

--- a/README.md
+++ b/README.md
@@ -6,12 +6,14 @@ A self hostable service for sending ebooks to a Kobo or Kindle ereader through t
 
 ### On Your Host OS
 
-1. Have Node 16 installed
+1. Have Node.js 16 or 20 installed
 2. Install this service's dependencies by running `$ npm install`
-3. Install [Kepubify](https://github.com/pgaskin/kepubify), and have the executable in your path.
-4. Start this service by running: `$ node index`
+3. Install [Kepubify](https://github.com/pgaskin/kepubify), and have the kepubify executable in your PATH.
+4. Install [KindleGen](https://archive.org/details/kindlegen2.9), and have the kindlegen executable in your PATH.
+5. Start this service by running: `$ npm start` and access it on HTTP port 3001
 
 ### Containerized
 
 1. Have Docker installed
 2. Run `$ docker compose up`
+3. Access the service on HTTP port 3001

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,6 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile
-    container_name: send3ereader
+    container_name: send2ereader
     ports:
       - 3001:3001

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,9 @@
+version: "3"
+services:
+  send2ereader:
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    container_name: send3ereader
+    ports:
+      - 3001:3001


### PR DESCRIPTION
Hey @daniel-j , I got your lovely service running in a Docker environment. I added some rudimentary documentation on how to leverage the new `Dockerfile` and `docker-compose.yaml` file.

Please let me know if you have any requested changes, but I have been able to run this service using Docker and leverage it with my Kobo Clara HD just fine.