### PR TITLE
Update Readme.md and docker-compose.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,17 @@ A self hostable service for sending ebooks to a Kobo or Kindle ereader through t
 6. Start this service by running: `$ npm start` and access it on HTTP port 3001
 
 ### Containerized
-
-1. Have Docker installed
-2. Run `$ docker compose up`
-3. Access the service on HTTP port 3001
+1. You need [Docker](https://www.docker.com/) and [docker-compose](https://docs.docker.com/compose/) installed
+2. Clone this repo (you need Dockerfile, docker-compose.yaml and package.json in the same directory)
+```
+git clone https://github.com/daniel-j/send2ereader.git
+```
+3. Build the image
+```
+docker compose build
+```
+4. run container (-d to keep running in the background)
+```
+docker compose up -d
+```
+5. Access the service on HTTP, default port 3001 (http://localhost:3001)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,9 +1,12 @@
-version: "3"
 services:
   send2ereader:
     build:
       context: .
       dockerfile: ./Dockerfile
     container_name: send2ereader
+    # Restart means, Automatic re-start the container after a shutdown unless manual stop container
+    restart: unless-stopped
+    # ports means, Bind external and internal docker ports, only change the external port, not the internal port
+    # Arquitecture: <External Port>:<Internal Port>
     ports:
       - 3001:3001


### PR DESCRIPTION
I hope this littles changes help someone, its all minor changes

When i was installing, i forget to clone or have the correct file in the directory and i can't build the image, clone the repo was solving that issue, so i think could help

**Readme.md changes**
I added more info to containerized section
- Git Clone, this is the most easy way to get Dockerfile, docker-compose.yaml and package.json
- Build the image, to check is every step is going okey, if something failed, people can see where step is failing instead of running from start to end in one run
- run container, the same step as the original readme

**docker-compose.yaml changes**
- I delete "version" because is deprecated/obsolete
- I added "restart" because help to not start the container every boot
- I added also comment to explain how ports work in docker, this help when port 3001 is already used, and need to change for other

---

PD: This is my first PR, so feedback will be welcome, i love this repo, now i cant not only send files in my lan but every part of the world, its awesome