### PR TITLE
Make download URL relative from subdirectory ('./') vs relative from root ('/')

### DIFF
--- a/static/download.html
+++ b/static/download.html
@@ -82,7 +82,7 @@ function pollFile () {
 		if (data.file) {
 			downloads.style.display = 'block'
 			downloadlink.textContent = data.file.name
-			downloadlink.href = '/' + encodeURIComponent(data.file.name) + "?key=" + key
+			downloadlink.href = './' + encodeURIComponent(data.file.name) + "?key=" + key
 		} else {
 			downloads.style.display = 'none'
 		}


### PR DESCRIPTION
Pretty straightforward change — this changes the download link to be relative to the current directory, rather than relative to the root.

I host the site at a subdirectory which works great _except_ that the download link gets set to `/[file]` — i.e. pointed to a file at the root of the site — and all download links 404. This resolves that issue.

For sites operating at the root (i.e. send.djazz.se) this will still point the download to the correct location.

(Love this app and use the hell out of it @daniel-j so thank you!)