### PR TITLE
[FIX] Issue #42: epub can’t upload

### DIFF
--- a/index.js
+++ b/index.js
@@ -597,7 +597,7 @@ router.get('/receive', async ctx => {
 router.get('/', async ctx => {
   const agent = ctx.get('user-agent')
   console.log(ctx.ip, agent)
-  await sendfile(ctx, agent.includes('Kobo') || agent.includes('Kindle') || agent.includes('Linux') || agent.toLowerCase().includes('tolino') || agent.includes('eReader') /*"eReader" is on Tolino*/ ? 'static/download.html' : 'static/upload.html')
+  await sendfile(ctx, agent.includes('Kobo') || agent.includes('Kindle') || agent.toLowerCase().includes('tolino') || agent.includes('eReader') /*"eReader" is on Tolino*/ ? 'static/download.html' : 'static/upload.html')
 })
 
 router.get('/:filename', downloadFile)


### PR DESCRIPTION
This is a fix for issue #42. The problem was that the mimetype was `application/epub` instead of being `application/epub+zip` (see [IANA standards](https://www.iana.org/assignments/media-types/media-types.xhtml)).